### PR TITLE
guard against message.type undefined

### DIFF
--- a/src/api/helpers/decrypt.ts
+++ b/src/api/helpers/decrypt.ts
@@ -47,7 +47,7 @@ function generateFile(
 function expandDerivation(mediaType: string, mediaKeyBase64: string) {
   const options: hkdf.Options = {
     salt: new Uint8Array(32) as any,
-    info: `WhatsApp ${MediaType[mediaType.toUpperCase()]} Keys`,
+    info: `WhatsApp ${mediaType && MediaType[mediaType.toUpperCase()] || 'Unknown'} Keys`,
     hash: 'sha256',
   };
 


### PR DESCRIPTION
I just had the case where `message.type` was `undefined` and then this function crashed on `.toUpperCase()` on `undefined`.