### PR TITLE
events support #291

### DIFF
--- a/src/controllers/events.ts
+++ b/src/controllers/events.ts
@@ -1,0 +1,3 @@
+const EventEmitter = require('events');
+
+export const events = new EventEmitter();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export {
 } from './api/model/enum';
 export { Whatsapp } from './api/whatsapp';
 export { create } from './controllers/initializer';
+export { events } from './controllers/events';


### PR DESCRIPTION
This PR adds support to this events:

- `initialized` => (waPage) : emitted when waPage is opened successfully
- `qrCode` => (data, ascii): emitted when qrCode is catched
- `authenticated` => void: emitted when successfully authenticated
- `error` => err: emitted when waPage crashes
- `pageError` => err: emitted when waPage gets an uncaught exception on console